### PR TITLE
Removed the environment section from Datamover config.json. 

### DIFF
--- a/roles/create_datamover_conf/templates/config.json.j2
+++ b/roles/create_datamover_conf/templates/config.json.j2
@@ -58,11 +58,6 @@
     },
     "installation_path": "{{ target_dir }}"
   },
-  "environment": {
-    "gcc" : {
-      "required": true
-    }
-  },
   "aws": {
    "awslib_log_debug": {{ datamover_awslib_log_debug }}
   }

--- a/roles/create_datamover_conf/templates/config.json.j2
+++ b/roles/create_datamover_conf/templates/config.json.j2
@@ -58,13 +58,6 @@
     },
     "installation_path": "{{ target_dir }}"
   },
-  "environment": {
-    "gcc" : {
-      "version": "{{ datamover_gcc_version }}",
-      "source" : "{{ gcc_setenv }}",
-      "required": true
-    }
-  },
   "aws": {
    "awslib_log_debug": {{ datamover_awslib_log_debug }}
   }

--- a/roles/create_datamover_conf/templates/config.json.j2
+++ b/roles/create_datamover_conf/templates/config.json.j2
@@ -58,6 +58,11 @@
     },
     "installation_path": "{{ target_dir }}"
   },
+  "environment": {
+    "gcc" : {
+      "required": true
+    }
+  },
   "aws": {
    "awslib_log_debug": {{ datamover_awslib_log_debug }}
   }


### PR DESCRIPTION
Removed the gcc environment section from Datamover config.json. Since the Gen-1 uses gcc-5.1 and Gen-2 uses devtoolset-11, the deployment will be messed up if the user/pipelines doesn't handle the change. Datamover code defaults to the above versions if not specified.