### PR TITLE
Add quotes to compaction string

### DIFF
--- a/roles/create_datamover_conf/templates/config.json.j2
+++ b/roles/create_datamover_conf/templates/config.json.j2
@@ -68,5 +68,5 @@
   "aws": {
    "awslib_log_debug": {{ datamover_awslib_log_debug }}
   },
-  "compaction": {{ datamover_compaction }}
+  "compaction": "{{ datamover_compaction }}"
 }


### PR DESCRIPTION
Datamover fails with bare keyword (`yes`, `no`).
Needs to be quoted as string.