### PR TITLE
Use version comparison test.

### DIFF
--- a/roles/configure_host_only_vlans/handlers/main.yml
+++ b/roles/configure_host_only_vlans/handlers/main.yml
@@ -31,7 +31,7 @@
 
 - name: Restart network service
   service:
-    name: "{% if ansible_distribution_version == '8' %}NetworkManager{% else %}network{% endif %}"
+    name: "{% if ansible_distribution_version is version('8.0', '>=') %}NetworkManager{% else %}network{% endif %}"
     state: restarted
   become: true
 

--- a/roles/configure_host_vlans/handlers/main.yml
+++ b/roles/configure_host_vlans/handlers/main.yml
@@ -31,7 +31,7 @@
 
 - name: Restart network service
   service:
-    name: "{% if ansible_distribution_version == '8' %}NetworkManager{% else %}network{% endif %}"
+    name: "{% if ansible_distribution_version is version('8.0', '>=') %}NetworkManager{% else %}network{% endif %}"
     state: restarted
   become: true
 

--- a/roles/remove_host_vlans/handlers/main.yml
+++ b/roles/remove_host_vlans/handlers/main.yml
@@ -31,7 +31,7 @@
 
 - name: Restart network service
   service:
-    name: "{% if ansible_distribution_version == '8' %}NetworkManager{% else %}network{% endif %}"
+    name: "{% if ansible_distribution_version is version('8.0', '>=') %}NetworkManager{% else %}network{% endif %}"
     state: restarted
   become: true
 


### PR DESCRIPTION
- old code used string compare and failed against newer CentOS or Rocky
- Now use version compare test
- This change is tested against Rocky Linux 8.7