### PR TITLE
Set ldconfig for dss-sdk libs

### DIFF
--- a/roles/deploy_dss_host/defaults/main.yml
+++ b/roles/deploy_dss_host/defaults/main.yml
@@ -33,6 +33,7 @@
 artifacts_dir: "{{ inventory_dir }}/artifacts"
 dss_dir: /usr/dss
 nkv_sdk_dir: "{{ dss_dir }}/nkv-sdk"
+nkv_sdk_lib_dir: "{{ nkv_sdk_dir }}/lib"
 
 ### PIP defaults
 pip2_version: 20.3.4

--- a/roles/deploy_dss_host/handlers/main.yml
+++ b/roles/deploy_dss_host/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Run ldconfig
+  command: ldconfig
+  become: true

--- a/roles/deploy_dss_host/tasks/main.yml
+++ b/roles/deploy_dss_host/tasks/main.yml
@@ -118,3 +118,14 @@
     group: root
     mode: 0555
   become: true
+
+- name: Set ld.conf.so
+  copy:
+    dest: /etc/ld.so.conf.d/dss_host.conf
+    content: |
+      # DSS libs for dss-sdk host
+      {{ nkv_sdk_lib_dir }}
+
+    mode: 0644
+  notify: Run ldconfig
+  become: true

--- a/roles/deploy_dss_target/defaults/main.yml
+++ b/roles/deploy_dss_target/defaults/main.yml
@@ -32,6 +32,7 @@
 ### Path defaults
 dss_dir: /usr/dss
 target_dir: "{{ dss_dir }}/nkv-target"
+target_lib_dir: "{{ target_dir }}/lib"
 artifacts_dir: "{{ inventory_dir }}/artifacts"
 dss_log_dir: /var/log/dss
 target_conf_dir: /etc/dss

--- a/roles/deploy_dss_target/handlers/main.yml
+++ b/roles/deploy_dss_target/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+
+- name: Run ldconfig
+  command: ldconfig
+  become: true

--- a/roles/deploy_dss_target/tasks/main.yml
+++ b/roles/deploy_dss_target/tasks/main.yml
@@ -118,6 +118,17 @@
   when: xrt_tgz.files | length > 0
   become: true
 
+- name: Set ld.conf.so
+  copy:
+    dest: /etc/ld.so.conf.d/dss_target.conf
+    content: |
+      # DSS libs for dss-sdk target
+      {{ target_lib_dir }}
+
+    mode: 0644
+  notify: Run ldconfig
+  become: true
+
 - name: Create log dir
   file:
     path: "{{ dss_log_dir }}"


### PR DESCRIPTION
- Create ld.so.conf.d file for dss-sdk target
- Create ld.so.conf.d file for dss-sdk host
- Run ldconfig if either file changes
- This automatically adds all DSS libs into context
- No need for LD_LIBRARY_PATH var after this