### PR TITLE
Add download_artifacts playbook and role

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,14 @@ By default, core dumps will be compressed and stored in `/var/crash`.
 Please ensure your host has enough disk space to store core dumps, if you wish to use for debugging.
 This path can be changed by setting the `coredump_dir` var. see: /group_vars/all.yml
 
+#### playbooks/download_artifacts.yml
+
+Execute this playbook to download artifacts from the dss-artifacts S3 bucket.
+
+By default, this playbook will download artifacts from the public AWS S3 dss-artifacts bucket (public HTTP URL).
+The bucket URL can be overridden with the public URL of any S3-compatible bucket (eg: MinIO, DSS).
+Additionally, the branch name can also be overridden.
+
 #### playbooks/format_redeploy_dss_software.yml
 
 Execute this playbook to re-deploy DSS software to all hosts in your inventory.

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -29,6 +29,10 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---
 
+### Artifacts defaults
+# artifacts_url: https://dss-artifacts.s3.us-west-1.amazonaws.com
+# artifacts_branch: master
+
 ### Path defaults
 # ansible_log_path: ~/.dss_ansible.log
 # artifacts_dir: "{{ inventory_dir }}/artifacts"

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -32,6 +32,7 @@
 ### Artifacts defaults
 # artifacts_url: https://dss-artifacts.s3.us-west-1.amazonaws.com
 # artifacts_branch: master
+# download_artifacts: true
 
 ### Path defaults
 # ansible_log_path: ~/.dss_ansible.log

--- a/playbooks/deploy_dss_software.yml
+++ b/playbooks/deploy_dss_software.yml
@@ -52,6 +52,9 @@
   roles:
     - validate_ansible
 
+- name: Download Artifacts
+  import_playbook: download_artifacts.yml
+
 - name: Check IOMMU Off
   gather_facts: false
   hosts:

--- a/playbooks/download_artifacts.yml
+++ b/playbooks/download_artifacts.yml
@@ -1,0 +1,46 @@
+# The Clear BSD License
+#
+# Copyright (c) 2022 Samsung Electronics Co., Ltd.
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted (subject to the limitations in the disclaimer
+# below) provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Samsung Electronics Co., Ltd. nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+# NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE GRANTED BY
+# THIS LICENSE. THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+# CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT
+# NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS;
+# OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+# WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+# OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF
+# ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+---
+
+### Playbook Documentation ###
+#
+# #### playbooks/download_artifacts.yml
+#
+# Execute this playbook to download artifacts from the dss-artifacts S3 bucket.
+#
+# By default, this playbook will download artifacts from the public AWS S3 dss-artifacts bucket (public HTTP URL).
+# The bucket can be overridden with the public URL of any S3-compatible bucket (eg: MinIO, DSS)
+# Additionally, the branch name can also be overridden.
+
+- name: Download DSS Artifacts
+  hosts: localhost
+  gather_facts: false
+  roles:
+    - download_artifacts

--- a/roles/download_artifacts/defaults/main.yml
+++ b/roles/download_artifacts/defaults/main.yml
@@ -1,0 +1,8 @@
+---
+
+### Path defaults
+artifacts_dir: "{{ lookup('env', 'PWD')  }}/artifacts"
+
+### Artifacts defaults
+artifacts_url: https://dss-artifacts.s3.us-west-1.amazonaws.com
+artifacts_branch: master

--- a/roles/download_artifacts/defaults/main.yml
+++ b/roles/download_artifacts/defaults/main.yml
@@ -6,3 +6,4 @@ artifacts_dir: "{{ lookup('env', 'PWD')  }}/artifacts"
 ### Artifacts defaults
 artifacts_url: https://dss-artifacts.s3.us-west-1.amazonaws.com
 artifacts_branch: master
+download_artifacts: true

--- a/roles/download_artifacts/tasks/main.yml
+++ b/roles/download_artifacts/tasks/main.yml
@@ -7,6 +7,7 @@
     return_content: true
   register: artifacts_xml
   run_once: true
+  when: download_artifacts | bool
 
 - name: Set list of artifacts for branch
   ansible.builtin.set_fact:
@@ -14,9 +15,11 @@
   vars:
     regex: "<Key>({{ artifacts_branch }}/[^<]+?(?=<))"
   run_once: true
+  when: download_artifacts | bool
 
 - name: Download artifacts from dss-artifacts bucket
   ansible.builtin.get_url:
     url: "{{ artifacts_url }}/{{ item }}"
     dest: "{{ artifacts_dir }}"
   loop: "{{ dss_artifacts_list }}"
+  when: download_artifacts | bool

--- a/roles/download_artifacts/tasks/main.yml
+++ b/roles/download_artifacts/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+
+- name: Fetch contents of dss-artifacts bucket
+  ansible.builtin.uri:
+    url: " {{ artifacts_url }}"
+    method: GET
+    return_content: true
+  register: artifacts_xml
+  run_once: true
+
+- name: Set list of artifacts for branch
+  ansible.builtin.set_fact:
+    dss_artifacts_list: "{{ artifacts_xml.content | regex_findall(regex) }}"
+  vars:
+    regex: "<Key>({{ artifacts_branch }}/[^<]+?(?=<))"
+  run_once: true
+
+- name: Download artifacts from dss-artifacts bucket
+  ansible.builtin.get_url:
+    url: "{{ artifacts_url }}/{{ item }}"
+    dest: "{{ artifacts_dir }}"
+  loop: "{{ dss_artifacts_list }}"


### PR DESCRIPTION
- Allows automatic download of latest artifacts from public s3
- by default master branch artifacts are downloaded
- s3 url can be overridden
- branch name can be overridden