### PR TITLE
Catch mkfs blobfs core dump condition

### DIFF
--- a/roles/format_blobfs/tasks/format_blobfs.yml
+++ b/roles/format_blobfs/tasks/format_blobfs.yml
@@ -98,4 +98,6 @@
     - Init subsystem bdev failed
     - nvme_identify_controller failed
     - Failed to initialize SSD
+    - core dumped
+    - Illegal instruction
   when: format_disks is not skipped

--- a/roles/format_blobfs/tasks/format_blobfs.yml
+++ b/roles/format_blobfs/tasks/format_blobfs.yml
@@ -72,6 +72,8 @@
     pre_format_disks.stdout is search('nvme_identify_controller failed') or
     pre_format_disks.stdout is search('Failed to initialize SSD') or
     pre_format_disks.stdout is search('error while loading shared libraries') or
+    pre_format_disks.stdout is search('core dumped') or
+    pre_format_disks.stdout is search('Illegal instruction') or
     pre_format_disks.stdout is not search('Initializing filesystem on bdev') or
     create_format_disks_template.changed or
     create_blobfs_conf.changed


### PR DESCRIPTION
We are missing detection when mkfs_blobfs fails due to core dump / Illegal instruction condition.

Added missing assertions.