### PR TITLE
Include vars for network service

### DIFF
--- a/roles/remove_host_vlans/tasks/main.yml
+++ b/roles/remove_host_vlans/tasks/main.yml
@@ -29,6 +29,9 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---
 
+- name: Include vars
+  include_vars: "{{ ansible_distribution_file_variety | lower }}_{{ ansible_distribution_major_version }}.yml"
+
 - name: Get VLAN map
   include_role:
     name: get_vlan_map


### PR DESCRIPTION
`include_vars` was mistakenly left out of previous PR.