### PR TITLE
Don't delete /etc/dss on remove plays

### DIFF
--- a/playbooks/remove_vlans.yml
+++ b/playbooks/remove_vlans.yml
@@ -44,8 +44,6 @@
 
 - name: Remove DSS Software
   import_playbook: remove_dss_software.yml
-  vars:
-    remove_etc: false
 
 - name: Get Onyx LLDP tables
   hosts: onyx

--- a/roles/remove_dss_software/defaults/main.yml
+++ b/roles/remove_dss_software/defaults/main.yml
@@ -35,7 +35,6 @@ target_conf_dir: /etc/dss
 xrt_dir: /opt/xilinx
 
 ### Remove DSS defaults
-remove_etc: true
 remove_dss_software_dir_list:
   - "{{ dss_dir }}"
   - "{{ xrt_dir }}"

--- a/roles/remove_dss_software/tasks/main.yml
+++ b/roles/remove_dss_software/tasks/main.yml
@@ -29,11 +29,6 @@
 # ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ---
 
-- name: Remove Target Configuration Directory on Remove
-  set_fact:
-    remove_dss_software_dir_list: "{{ remove_dss_software_dir_list + [ target_conf_dir ] }}"
-  when: remove_etc
-
 - name: Remove DSS Software
   file:
     path: "{{ dss_path }}"


### PR DESCRIPTION
Do not delete `/etc/dss` on `remove_dss_software` or `format_redeploy` plays.

This is needed due to an edge case that pops up when MinIO Cleanup script is needed. MinIO Cleanup will fail if the client library conf is missing (eg, after `/etc/dss` was deleted).