### PR TITLE
Fix onyx group vars

### DIFF
--- a/group_vars/onyx.yml
+++ b/group_vars/onyx.yml
@@ -2,6 +2,5 @@
 
 ansible_connection: network_cli
 ansible_network_os: onyx
-gather_facts: false
-become: true
-become_method: enable
+ansible_become: true
+ansible_become_method: enable

--- a/playbooks/configure_vlans.yml
+++ b/playbooks/configure_vlans.yml
@@ -83,12 +83,7 @@
 
 - name: Get Onyx LLDP tables
   hosts: onyx
-  connection: network_cli
   gather_facts: false
-  become: true
-  become_method: enable
-  vars:
-    ansible_network_os: onyx
   roles:
     - get_onyx_lldp
 
@@ -104,11 +99,6 @@
 
 - name: Configure Onyx VLANs
   hosts: onyx
-  connection: network_cli
   gather_facts: false
-  become: true
-  become_method: enable
-  vars:
-    ansible_network_os: onyx
   roles:
     - configure_onyx_vlans

--- a/playbooks/remove_vlans.yml
+++ b/playbooks/remove_vlans.yml
@@ -47,12 +47,7 @@
 
 - name: Get Onyx LLDP tables
   hosts: onyx
-  connection: network_cli
   gather_facts: false
-  become: true
-  become_method: enable
-  vars:
-    ansible_network_os: onyx
   roles:
     - get_onyx_lldp
 
@@ -67,11 +62,6 @@
 
 - name: Remove Onyx allowed VLANs
   hosts: onyx
-  connection: network_cli
   gather_facts: false
-  become: true
-  become_method: enable
-  vars:
-    ansible_network_os: onyx
   roles:
     - remove_onyx_allowed_vlans


### PR DESCRIPTION
- `gather_facts` cannot be defined in group_vars
- `become` and `become_method` cannot be defined in group_vars, but `ansible_become` and `ansible_become_method` can
- since these are now defined in `group_vars` we can remove the overrides from the onyx playbooks
- This fixes a regression where some onyx commands fail, for example any command using `| json-print`

Confirmed above changes resolve regression.