### PR TITLE
Allow a default value to be overridden

### DIFF
--- a/roles/get_mountpoints/tasks/main.yml
+++ b/roles/get_mountpoints/tasks/main.yml
@@ -31,7 +31,7 @@
 
 - name: Init vars
   set_fact:
-    standalone_minio: false
+    standalone_minio: "{{ standalone_minio | d(false)}}"
 
 - name: Get Combined VLAN IP map
   include_role:


### PR DESCRIPTION
Allow standalone minio to be set from vars.
Pass `standalone_minio=true` to force non-distributed, standlone MinIO, EG from your inventory file.