### PR TITLE
Only fetch artifacts from matching branch

### DIFF
--- a/roles/download_artifacts/tasks/main.yml
+++ b/roles/download_artifacts/tasks/main.yml
@@ -18,6 +18,16 @@
   run_once: true
   when: download_artifacts | bool
 
+- name: Check artifacts found
+  ansible.builtin.assert:
+    that: dss_artifacts_list | length > 0
+    fail_msg: |
+      No artifacts found. Check vars:
+      artifacts_url: {{ artifacts_url }}
+      artifacts_branch: {{ artifacts_branch }}
+    quiet: true
+  run_once: true
+
 - name: Download artifacts from dss-artifacts bucket
   ansible.builtin.get_url:
     url: "{{ artifacts_url }}/{{ item }}"

--- a/roles/download_artifacts/tasks/main.yml
+++ b/roles/download_artifacts/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Fetch contents of dss-artifacts bucket
   ansible.builtin.uri:
-    url: " {{ artifacts_url }}"
+    url: " {{ artifacts_url }}?prefix={{ artifacts_branch }}"
     method: GET
     return_content: true
     validate_certs: "{{ artifacts_validate_certs }}"

--- a/roles/download_artifacts/tasks/main.yml
+++ b/roles/download_artifacts/tasks/main.yml
@@ -2,7 +2,7 @@
 
 - name: Fetch contents of dss-artifacts bucket
   ansible.builtin.uri:
-    url: " {{ artifacts_url }}?prefix={{ artifacts_branch }}"
+    url: "{{ artifacts_url }}?prefix={{ artifacts_branch }}"
     method: GET
     return_content: true
     validate_certs: "{{ artifacts_validate_certs }}"

--- a/roles/download_artifacts/tasks/main.yml
+++ b/roles/download_artifacts/tasks/main.yml
@@ -27,6 +27,7 @@
       artifacts_branch: {{ artifacts_branch }}
     quiet: true
   run_once: true
+  when: download_artifacts | bool
 
 - name: Download artifacts from dss-artifacts bucket
   ansible.builtin.get_url:


### PR DESCRIPTION
* use artifacts_branch as prefix
* assert that artifacts are found before downloading

Previously we fetched the entire bucket when looking for artifacts from S3 public endpoint. Unfortunately the API limits the response to 1,000 objects, so we quickly hit this barrier after introducing the cache subdir used for CICD pipelines.

This is not an issue if we restrict the `ListBucketResult` to the `prefix` matching the branch name we want to download artifacts for.

I've tested this change both for public AWS S3 artifacts bucket as well as local private MinIO endpoint.

Additionally if artifacts are not found for some reason, the play would previously continue without error. Now this will result in a failure via assertion.