### PR TITLE
Update paths for s3 benchmark

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,7 +850,7 @@ Note that software will only be upgraded if new binaries are placed under the "a
 ### Wasabi Benchmark Program (s3-benchmark)
 
 Wasabi Benchmark (s3-benchmark) is a performance testing tool that can validate performance of standard S3 operations (PUT, GET, and DELETE) on the MinIO object store.
-It is automatically installed by Ansible to `/usr/dss/nkv-minio/s3-benchmark` on each host in the [servers] and [clients] groups.
+It is automatically installed by Ansible to `/usr/dss/client-library/s3-benchmark` on each host in the [servers] and [clients] groups.
 
 For complete documentation please see <https://github.com/wasabi-tech/s3-benchmark>.
 
@@ -902,7 +902,7 @@ Compaction reduces the dataset footprint on back-end storage and ensures optimal
 
 Command:
 
-    [ansible@server-vm01 ~]$ /usr/dss/nkv-minio/s3-benchmark -a minio -s minio123 -b testbucket -u http://192.168.200.1:9000 -t 100 -z 1M -n 100 -o 1
+    [ansible@server-vm01 ~]$ /usr/dss/client-library/s3-benchmark -a minio -s minio123 -b testbucket -u http://192.168.200.1:9000 -t 100 -z 1M -n 100 -o 1
 
 Output:
 
@@ -920,7 +920,7 @@ Command:
 
 Command:
 
-    [ansible@server-vm01 ~]$ /usr/dss/nkv-minio/s3-benchmark -a minio -s minio123 -b testbucket -u http://192.168.200.1:9000 -t 100 -z 1M -n 100 -o 2
+    [ansible@server-vm01 ~]$ /usr/dss/client-library/s3-benchmark -a minio -s minio123 -b testbucket -u http://192.168.200.1:9000 -t 100 -z 1M -n 100 -o 2
 
 Output:
 
@@ -932,7 +932,7 @@ Output:
 
 Command:
 
-    [ansible@server-vm01 ~]$ /usr/dss/nkv-minio/s3-benchmark -a minio -s minio123 -b testbucket -u http://192.168.200.1:9000 -t 100 -z 1M -n 100 -o 3
+    [ansible@server-vm01 ~]$ /usr/dss/client-library/s3-benchmark -a minio -s minio123 -b testbucket -u http://192.168.200.1:9000 -t 100 -z 1M -n 100 -o 3
 
 Output:
 

--- a/roles/test_s3_benchmark/defaults/main.yml
+++ b/roles/test_s3_benchmark/defaults/main.yml
@@ -32,7 +32,7 @@
 ### Path defaults
 artifacts_dir: "{{ inventory_dir }}/artifacts"
 dss_dir: /usr/dss
-minio_dir: "{{ dss_dir }}/nkv-minio"
+client_library_dir: "{{ dss_dir }}/client-library"
 
 ### s3_benchmark defaults
 s3_benchmark_bucket_prefix: s3-bucket-

--- a/roles/test_s3_benchmark/tasks/main.yml
+++ b/roles/test_s3_benchmark/tasks/main.yml
@@ -39,15 +39,15 @@
     name: numactl
   become: true
 
-- name: Stat DSS Minio path
+- name: Stat DSS Client path
   stat:
-    path: "{{ minio_dir }}"
-  register: dss_minio_path
+    path: "{{ client_library_dir }}"
+  register: dss_client_path
   when: inventory_hostname in host_hostnames
 
 - name: Assert DSS Minio path exists
   assert:
-    that: dss_minio_path.stat.exists
+    that: dss_client_path.stat.exists
     fail_msg: DSS Minio is not installed. Execute 'deploy_dss_software.yml' playbook first.
   when: inventory_hostname in host_hostnames
 

--- a/roles/test_s3_benchmark/tasks/s3_benchmark.yml
+++ b/roles/test_s3_benchmark/tasks/s3_benchmark.yml
@@ -60,7 +60,7 @@
       {% if num_numa | int > 1 -%}
       numactl -N {{ numa }} -m {{ adjacent_numa }}
       {% endif -%}
-      {{ minio_dir }}/s3-benchmark
+      {{ client_library_dir }}/s3-benchmark
       -a {{ minio_access_key }}
       -s {{ minio_secret_key }}
       -b {{ s3_benchmark_bucket_prefix }}{{ cluster_id }}

--- a/roles/test_s3_benchmark/tasks/s3_benchmark.yml
+++ b/roles/test_s3_benchmark/tasks/s3_benchmark.yml
@@ -30,12 +30,12 @@
 ---
 
 - name: Assert operation is valid
-  assert:
+  ansible.builtin.assert:
     that: operation in ['PUT', 'GET', 'DEL']
   run_once: true
 
 - name: Set operation_num var
-  set_fact:
+  ansible.builtin.set_fact:
     operation_num: >-
       {%- if operation == 'PUT' -%}
         {{ s3_bench_put }}
@@ -47,7 +47,7 @@
   run_once: true
 
 - name: "Execute s3-benchmark {{ operation }}"
-  command: "{{ s3_bench_command }}"
+  ansible.builtin.command: "{{ s3_bench_command }}"
   loop: "{{ assigned_endpoints }}"
   loop_control:
     loop_var: endpoint
@@ -83,7 +83,7 @@
   poll: 0
 
 - name: "Check async s3-benchmark {{ operation }} command"
-  async_status:
+  ansible.builtin.async_status:
     jid: "{{ async_task.ansible_job_id }}"
   register: async_results
   until: async_results.finished
@@ -95,7 +95,7 @@
     label: "{{ async_task.endpoint.endpoint }}"
 
 - name: "Assert async s3-benchmark {{ operation }} completion"
-  assert:
+  ansible.builtin.assert:
     that: async_result.finished != 0
     fail_msg: "nkv_test_cli did not complete in time"
     quiet: true
@@ -105,7 +105,7 @@
     label: "{{ async_result.cmd | join(' ') }}"
 
 - name: "Assert s3-benchmark {{ operation }} results valid"
-  assert:
+  ansible.builtin.assert:
     that: async_result.stdout is regex(objects_re)
     fail_msg: "Did not get valid s3-benchmark result"
     quiet: true
@@ -118,7 +118,7 @@
   when: operation != 'DEL'
 
 - name: Set test_seconds var
-  set_fact:
+  ansible.builtin.set_fact:
     test_seconds: >-
       {%- set elapsed_time = {'start': '', 'end': ''} -%}
       {%- for client in groups['clients'] -%}
@@ -140,7 +140,7 @@
   when: operation != 'DEL'
 
 - name: set s3_speed var
-  set_fact:
+  ansible.builtin.set_fact:
     s3_speed: >-
       {%- set total_objects = {'value': 0} -%}
       {%- set objects_re = 'objects = ([\d]+),' -%}


### PR DESCRIPTION
* s3-benchmark is no longer packed with minio artifact
* s3-benchmark is now packaged with client-library
* paths need to be updated to reflect this change (both in play as well as documentation)
* in testing a minor regression was identified. Some tasks fail for an unexplained reason on latest version of ansible 2.9, but the problem goes away when the full path of the module name is supplied, rather than just the short name