### PR TITLE
Add missing sync-github stage variable override

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,3 +7,7 @@ stages:
   - deploy
   - test
   - sync
+
+sync-github:
+  variables:
+    GITHUB_REPO: dss-ansible


### PR DESCRIPTION
Add sync-github variable override.

Allows local gitlab sync job to execute.