### PR TITLE
Append tpoint_group_mask if defined

### DIFF
--- a/roles/start_dss_target/tasks/main.yml
+++ b/roles/start_dss_target/tasks/main.yml
@@ -105,6 +105,11 @@
       -m {{ custom_coremask }}
   when: custom_coremask is defined
 
+- name: Append tpoint_group_mask if defined
+  ansible.builtin.set_fact:
+    nvmf_tgt_cmd: "{{ nvmf_tgt_cmd }} --tpoint-group-mask {{ tpoint_group_mask }}"
+  when: tpoint_group_mask is defined
+
 - name: Find running target process
   ansible.builtin.command: "pgrep reactor_"
   register: nvmf_ps


### PR DESCRIPTION
This will add an undocumented feature for debugging use.

This will allow an optional nvmf_tgt command line argument to be passed during runtime.

Example: 

```
ansible-playbook -i inv_dss-ansible.ini playbooks/restart_dss_software.yml -e "tpoint_group_mask='0X0b'"
```